### PR TITLE
fix: P0 code fixes — i18n, pricing CTA, forgot password

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -113,7 +113,10 @@
     "passwordsMismatch": "Passwords don't match",
     "googleError": "Could not connect to Google. Please try again.",
     "or": "or",
-    "signupWithGoogle": "Sign up with Google"
+    "signupWithGoogle": "Sign up with Google",
+    "forgotPassword": "Forgot your password?",
+    "resetEmailSent": "Password reset email sent. Check your inbox.",
+    "enterEmailFirst": "Enter your email address first"
   },
   "pricing": {
     "title": "Choose your plan",
@@ -188,7 +191,9 @@
     "classical": "Classical",
     "pop": "Pop",
     "acoustic": "Acoustic",
-    "reggaeton": "Reggaeton Kids"
+    "reggaeton": "Reggaeton Kids",
+    "songsLabel": "songs",
+    "songsForChild": "{count} songs for {name}"
   },
   "generating": {
     "title": "Creating your song...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -113,7 +113,10 @@
     "passwordsMismatch": "Las contraseñas no coinciden",
     "googleError": "No se pudo conectar con Google. Intenta de nuevo.",
     "or": "o",
-    "signupWithGoogle": "Registrarse con Google"
+    "signupWithGoogle": "Registrarse con Google",
+    "forgotPassword": "¿Olvidaste tu contraseña?",
+    "resetEmailSent": "Email de recuperación enviado. Revisa tu bandeja de entrada.",
+    "enterEmailFirst": "Ingresa tu email primero"
   },
   "pricing": {
     "title": "Elige tu plan",
@@ -188,7 +191,9 @@
     "classical": "Clásico",
     "pop": "Pop",
     "acoustic": "Acústico",
-    "reggaeton": "Reggaeton Kids"
+    "reggaeton": "Reggaeton Kids",
+    "songsLabel": "canciones",
+    "songsForChild": "{count} canciones para {name}"
   },
   "generating": {
     "title": "Creando tu canción...",

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [resetSent, setResetSent] = useState(false);
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault();
@@ -133,9 +134,29 @@ export default function LoginPage() {
             </div>
 
             <div>
-              <label htmlFor="login-password" className="text-sm font-medium mb-1.5 block">
-                {t("password")}
-              </label>
+              <div className="flex items-center justify-between mb-1.5">
+                <label htmlFor="login-password" className="text-sm font-medium">
+                  {t("password")}
+                </label>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!email) {
+                      setError(t("enterEmailFirst"));
+                      return;
+                    }
+                    const supabase = createClient();
+                    await supabase.auth.resetPasswordForEmail(email, {
+                      redirectTo: `${window.location.origin}/auth/callback`,
+                    });
+                    setResetSent(true);
+                    setError("");
+                  }}
+                  className="text-xs text-primary hover:underline"
+                >
+                  {t("forgotPassword")}
+                </button>
+              </div>
               <div className="relative">
                 <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <input
@@ -150,6 +171,12 @@ export default function LoginPage() {
                 />
               </div>
             </div>
+
+            {resetSent && (
+              <p className="text-sm text-green-600 bg-green-50 px-3 py-2 rounded-lg">
+                {t("resetEmailSent")}
+              </p>
+            )}
 
             {error && (
               <p className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-lg">

--- a/src/app/[locale]/create/CreateWizard.tsx
+++ b/src/app/[locale]/create/CreateWizard.tsx
@@ -441,7 +441,7 @@ export default function CreateWizard({
                       albumCount === n ? "border-primary bg-primary/5 shadow-md" : "border-border hover:border-primary/50"
                     }`}>
                     <p className="text-3xl font-extrabold">{n}</p>
-                    <p className="text-sm text-muted-foreground mt-1">{t("next") === "Next" ? "songs" : "canciones"}</p>
+                    <p className="text-sm text-muted-foreground mt-1">{t("songsLabel")}</p>
                   </button>
                 ))}
               </div>
@@ -452,7 +452,7 @@ export default function CreateWizard({
             <div className="space-y-4">
               <div className="text-center mb-6">
                 <Sparkles className="h-12 w-12 text-primary mx-auto mb-4" />
-                <h2 className="text-xl font-bold">{albumCount} {t("next") === "Next" ? "songs" : "canciones"} para {childName}</h2>
+                <h2 className="text-xl font-bold">{t("songsForChild", { count: albumCount, name: childName })}</h2>
               </div>
               <button onClick={() => setAlbumMode("quick")}
                 className={`w-full p-6 rounded-2xl border-2 text-left transition-all ${albumMode === "quick" ? "border-primary bg-primary/5" : "border-border hover:border-primary/50"}`}>
@@ -484,7 +484,7 @@ export default function CreateWizard({
 
           {albumStep === "albumCustom" && (
             <div className="space-y-4">
-              <h2 className="text-xl font-bold text-center mb-4">{albumCount} {t("next") === "Next" ? "songs" : "canciones"} para {childName}</h2>
+              <h2 className="text-xl font-bold text-center mb-4">{t("songsForChild", { count: albumCount, name: childName })}</h2>
               {songConfigs.map((config, i) => (
                 <div key={i} className="p-4 rounded-xl border border-border bg-card">
                   <p className="font-bold text-sm mb-3">{t("albumSong", { number: i + 1 })}</p>
@@ -516,7 +516,7 @@ export default function CreateWizard({
           {albumStep === "albumConfirm" && (
             <div className="text-center space-y-6">
               <Disc3 className="h-16 w-16 text-primary mx-auto" />
-              <h2 className="text-2xl font-extrabold">{albumCount} {t("next") === "Next" ? "songs" : "canciones"} para {childName}</h2>
+              <h2 className="text-2xl font-extrabold">{t("songsForChild", { count: albumCount, name: childName })}</h2>
               <p className="text-muted-foreground">{t("language")}: {language.toUpperCase()}</p>
               {!albumHasCredits && (
                 <div className="bg-accent/20 border border-accent rounded-xl p-4">

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
 import { CREDIT_PACKS } from "@/lib/stripe/config";
+import { createClient } from "@/lib/supabase/server";
 
 export async function generateMetadata({
   params,
@@ -18,8 +19,17 @@ export async function generateMetadata({
   };
 }
 
-export default function PricingPage() {
+export default async function PricingPage() {
   const t = useTranslations("pricing");
+
+  let isLoggedIn = false;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    isLoggedIn = !!user;
+  } catch {
+    // Not logged in
+  }
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-16 sm:py-24">
@@ -54,7 +64,7 @@ export default function PricingPage() {
       </h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {Object.values(CREDIT_PACKS).map((pack) => (
+        {Object.entries(CREDIT_PACKS).map(([packKey, pack]) => (
           <div
             key={pack.name}
             className={`rounded-2xl bg-card p-8 flex flex-col relative ${
@@ -104,16 +114,29 @@ export default function PricingPage() {
               </li>
             </ul>
 
-            <Link
-              href="/auth/signup"
-              className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
-                pack.popular
-                  ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                  : "border border-border hover:bg-muted"
-              }`}
-            >
-              {t("buyCredits", { count: pack.credits })}
-            </Link>
+            {isLoggedIn ? (
+              <a
+                href={`/api/checkout?pack=${packKey}`}
+                className={`block py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+                  pack.popular
+                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "border border-border hover:bg-muted"
+                }`}
+              >
+                {t("buyCredits", { count: pack.credits })}
+              </a>
+            ) : (
+              <Link
+                href="/auth/signup"
+                className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+                  pack.popular
+                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "border border-border hover:bg-muted"
+                }`}
+              >
+                {t("buyCredits", { count: pack.credits })}
+              </Link>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- **i18n fix**: Replace hardcoded `t("next") === "Next" ? "songs" : "canciones"` in CreateWizard with proper translation keys (`songsLabel`, `songsForChild`)
- **Pricing CTA**: Buy button now routes to `/api/checkout?pack=X` for logged-in users instead of always going to `/auth/signup`
- **Forgot password**: Added "Forgot your password?" link on login page with Supabase `resetPasswordForEmail` flow

## Test plan
- [ ] Verify CreateWizard album flow shows correct text in both ES and EN
- [ ] Verify pricing page buy buttons go to checkout when logged in, signup when not
- [ ] Verify forgot password sends reset email and shows success message
- [ ] Verify empty email shows "enter email first" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)