### PR TITLE
fix: resolve pricing page 500 error

### DIFF
--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
-import { CREDIT_PACKS } from "@/lib/stripe/config";
+import { CREDIT_PACKS } from "@/lib/stripe/credit-packs";
 
 export const metadata = {
   title: "Pricing",

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -1,5 +1,8 @@
 import Stripe from "stripe";
 
+// Re-export credit packs for backward compatibility
+export { CREDIT_PACKS } from "./credit-packs";
+
 let _stripe: Stripe | null = null;
 
 export function getStripe() {
@@ -11,30 +14,3 @@ export function getStripe() {
 
 // Keep backward compat
 export const stripe = null as unknown as Stripe;
-
-export const CREDIT_PACKS = {
-  starter: {
-    name: "Starter",
-    credits: 3,
-    price: 4.99,
-    pricePerSong: 1.66,
-    priceId: process.env.STRIPE_STARTER_PACK_PRICE_ID || "",
-    popular: false,
-  },
-  popular: {
-    name: "Family Pack",
-    credits: 10,
-    price: 9.99,
-    pricePerSong: 1.0,
-    priceId: process.env.STRIPE_FAMILY_PACK_PRICE_ID || "",
-    popular: true,
-  },
-  mega: {
-    name: "Mega Pack",
-    credits: 25,
-    price: 19.99,
-    pricePerSong: 0.8,
-    priceId: process.env.STRIPE_MEGA_PACK_PRICE_ID || "",
-    popular: false,
-  },
-} as const;

--- a/src/lib/stripe/credit-packs.ts
+++ b/src/lib/stripe/credit-packs.ts
@@ -1,0 +1,29 @@
+// Credit pack definitions — separated from Stripe SDK to allow
+// importing in Server Components without loading the stripe package.
+
+export const CREDIT_PACKS = {
+  starter: {
+    name: "Starter",
+    credits: 3,
+    price: 4.99,
+    pricePerSong: 1.66,
+    priceId: process.env.STRIPE_STARTER_PACK_PRICE_ID || "",
+    popular: false,
+  },
+  popular: {
+    name: "Family Pack",
+    credits: 10,
+    price: 9.99,
+    pricePerSong: 1.0,
+    priceId: process.env.STRIPE_FAMILY_PACK_PRICE_ID || "",
+    popular: true,
+  },
+  mega: {
+    name: "Mega Pack",
+    credits: 25,
+    price: 19.99,
+    pricePerSong: 0.8,
+    priceId: process.env.STRIPE_MEGA_PACK_PRICE_ID || "",
+    popular: false,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- The `/pricing` page returns a **500 error** for all users (confirmed via direct HTTP request)
- Root cause: the pricing Server Component imported `CREDIT_PACKS` from `stripe/config.ts`, which also imports the `stripe` Node.js SDK — the SDK fails to bundle in Next.js 16 Server Components
- Fix: extracted `CREDIT_PACKS` to a standalone `credit-packs.ts` module with zero dependencies

## Changes
- **New** `src/lib/stripe/credit-packs.ts` — credit pack definitions only, no Stripe SDK import
- `src/lib/stripe/config.ts` — re-exports `CREDIT_PACKS` from new module (backward compatible)
- `src/app/[locale]/pricing/page.tsx` — imports from `credit-packs.ts` instead of `config.ts`

## Test plan
- [ ] Visit `/en/pricing` — verify page renders (currently returns 500)
- [ ] Visit `/es/pricing` — verify page renders
- [ ] Verify checkout flow still works (API routes still import from config.ts)
- [ ] Verify Stripe webhook still processes payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)