### PR TITLE
fix: pricing page renders blank (useTranslations in async component)

### DIFF
--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
@@ -20,8 +19,13 @@ export async function generateMetadata({
   };
 }
 
-export default async function PricingPage() {
-  const t = useTranslations("pricing");
+export default async function PricingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "pricing" });
 
   let isLoggedIn = false;
   try {


### PR DESCRIPTION
## Root cause
`useTranslations` es un React hook y no puede llamarse dentro de una función `async`. El componente `PricingPage` es un async Server Component, por lo que React silencia el error y renderiza una página en blanco sin ningún mensaje de error visible.

## Fix
Reemplazado `useTranslations("pricing")` por `await getTranslations({ locale, namespace: "pricing" })`, que es la versión server-side correcta para componentes async. Se agrega `params` al componente para obtener el locale (mismo patrón que `generateMetadata` en el mismo archivo).

## Test plan
- [ ] Visitar `/es/pricing` — verificar que la página carga con contenido
- [ ] Visitar `/en/pricing` — verificar que los textos están en inglés
- [ ] Verificar que los botones de pago se muestran correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)