### PR TITLE
fix: add missing metadata i18n namespace (blank page on all routes)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -118,6 +118,21 @@
     "resetEmailSent": "Password reset email sent. Check your inbox.",
     "enterEmailFirst": "Enter your email address first"
   },
+  "metadata": {
+    "defaultTitle": "BabyBeats — Personalized songs for your baby",
+    "defaultDescription": "Create unique songs with your baby's name using artificial intelligence.",
+    "ogDescription": "Lullabies, educational songs, and fun tunes crafted with AI for your baby.",
+    "pricingTitle": "Pricing — BabyBeats",
+    "pricingDescription": "First song free. Buy credit packs to create more personalized songs.",
+    "songsTitle": "Songs — BabyBeats",
+    "songsDescription": "Explore the catalog of baby songs created with artificial intelligence.",
+    "loginTitle": "Log in — BabyBeats",
+    "loginDescription": "Access your account to listen to and create personalized songs.",
+    "signupTitle": "Create account — BabyBeats",
+    "signupDescription": "Sign up for free and create your first personalized song for your baby.",
+    "giftTitle": "Gift BabyBeats",
+    "giftDescription": "The perfect gift: a personalized song album with the baby's name."
+  },
   "pricing": {
     "title": "Choose your plan",
     "subtitle": "Start free, upgrade when you're ready",

--- a/messages/es.json
+++ b/messages/es.json
@@ -118,6 +118,21 @@
     "resetEmailSent": "Email de recuperación enviado. Revisa tu bandeja de entrada.",
     "enterEmailFirst": "Ingresa tu email primero"
   },
+  "metadata": {
+    "defaultTitle": "BabyBeats — Canciones personalizadas para tu bebé",
+    "defaultDescription": "Crea canciones únicas con el nombre de tu bebé usando inteligencia artificial.",
+    "ogDescription": "Canciones de cuna, educativas y divertidas creadas con IA para tu bebé.",
+    "pricingTitle": "Planes y precios — BabyBeats",
+    "pricingDescription": "Primera canción gratis. Compra packs de créditos para crear más canciones personalizadas.",
+    "songsTitle": "Canciones — BabyBeats",
+    "songsDescription": "Explora el catálogo de canciones para bebés creadas con inteligencia artificial.",
+    "loginTitle": "Iniciar sesión — BabyBeats",
+    "loginDescription": "Accede a tu cuenta para escuchar y crear canciones personalizadas.",
+    "signupTitle": "Crear cuenta — BabyBeats",
+    "signupDescription": "Regístrate gratis y crea tu primera canción personalizada para tu bebé.",
+    "giftTitle": "Regala BabyBeats",
+    "giftDescription": "El regalo perfecto: un álbum de canciones personalizadas con el nombre del bebé."
+  },
   "pricing": {
     "title": "Elige tu plan",
     "subtitle": "Empieza gratis, mejora cuando quieras",


### PR DESCRIPTION
## Root cause
El namespace `"metadata"` se usa en 6 archivos del proyecto para generar los `<title>` y `<meta description>` de cada página, pero **nunca fue definido** en `es.json` ni `en.json`.

En desarrollo, next-intl solo registra un warning y sigue renderizando. En **producción**, lanza una excepción → la página queda completamente en blanco sin error visible.

Páginas afectadas: `/pricing`, `/songs`, `/auth/login`, `/auth/signup`, `/gift`, y el layout raíz.

## Fix
Agregado el namespace `metadata` a `messages/es.json` y `messages/en.json` con todas las claves requeridas:
- `defaultTitle`, `defaultDescription`, `ogDescription`
- `pricingTitle`, `pricingDescription`
- `songsTitle`, `songsDescription`
- `loginTitle`, `loginDescription`
- `signupTitle`, `signupDescription`
- `giftTitle`, `giftDescription`

## Test plan
- [ ] `/es/pricing` carga con contenido visible
- [ ] `/en/pricing` carga con contenido visible
- [ ] `<title>` de la pestaña muestra "Planes y precios — BabyBeats" en /es y "Pricing — BabyBeats" en /en
- [ ] Sin errores `MISSING_MESSAGE` en los logs del servidor

🤖 Generated with [Claude Code](https://claude.com/claude-code)