### PR TITLE
feat: checkout page redesign with currency selector

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -156,7 +156,18 @@
     "creditsNeverExpire": "Credits never expire",
     "buyCredits": "Buy {count} Credits",
     "payWithStripe": "Pay with card",
-    "payWithMP": "Pay with Mercado Pago"
+    "payWithMP": "Pay with Mercado Pago",
+    "choosePlan": "Choose plan",
+    "currencyUSD": "USD — Dollar",
+    "currencyCOP": "COP — Peso"
+  },
+  "checkout": {
+    "title": "Complete your purchase",
+    "orderSummary": "Order summary",
+    "credits": "{count} credits",
+    "payWithStripe": "Pay with card (Stripe)",
+    "payWithMP": "Pay with Mercado Pago",
+    "backToPricing": "Back to pricing"
   },
   "player": {
     "nowPlaying": "Now Playing",

--- a/messages/es.json
+++ b/messages/es.json
@@ -156,7 +156,18 @@
     "creditsNeverExpire": "Los créditos nunca expiran",
     "buyCredits": "Comprar {count} Créditos",
     "payWithStripe": "Pagar con tarjeta",
-    "payWithMP": "Pagar con Mercado Pago"
+    "payWithMP": "Pagar con Mercado Pago",
+    "choosePlan": "Elegir",
+    "currencyUSD": "USD — Dólar",
+    "currencyCOP": "COP — Peso"
+  },
+  "checkout": {
+    "title": "Completa tu compra",
+    "orderSummary": "Resumen del pedido",
+    "credits": "{count} créditos",
+    "payWithStripe": "Pagar con tarjeta (Stripe)",
+    "payWithMP": "Pagar con Mercado Pago",
+    "backToPricing": "Volver a precios"
   },
   "player": {
     "nowPlaying": "Reproduciendo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1613,22 +1612,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4455,20 +4438,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6389,38 +6358,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/po-parser": {

--- a/src/app/[locale]/checkout/[pack]/page.tsx
+++ b/src/app/[locale]/checkout/[pack]/page.tsx
@@ -1,0 +1,83 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { Link } from "@/i18n/routing";
+import { ArrowLeft, CreditCard } from "lucide-react";
+import { CREDIT_PACKS, CreditPackKey } from "@/lib/stripe/credit-packs";
+import { CREDIT_PACKS_COP } from "@/lib/mercado-pago/config";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function CheckoutPage({
+  params,
+}: {
+  params: Promise<{ locale: string; pack: string }>;
+}) {
+  const { locale, pack } = await params;
+
+  if (!(pack in CREDIT_PACKS)) {
+    redirect(`/${locale}/pricing`);
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/${locale}/auth/login?redirect=/${locale}/checkout/${pack}`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "checkout" });
+  const selectedPack = CREDIT_PACKS[pack as CreditPackKey];
+  const selectedPackCOP = CREDIT_PACKS_COP[pack as CreditPackKey];
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-16 sm:py-24">
+      <Link
+        href="/pricing"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("backToPricing")}
+      </Link>
+
+      <h1 className="text-3xl font-bold mb-8">{t("title")}</h1>
+
+      {/* Order summary */}
+      <div className="rounded-2xl border border-border bg-card p-6 mb-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-4">
+          {t("orderSummary")}
+        </p>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-bold text-lg">{selectedPack.name}</p>
+            <p className="text-sm text-muted-foreground">
+              {t("credits", { count: selectedPack.credits })}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="font-semibold">USD ${selectedPack.price}</p>
+            <p className="text-sm text-muted-foreground">
+              ${selectedPackCOP.price.toLocaleString("es-CO")} COP
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Payment methods */}
+      <div className="flex flex-col gap-3">
+        <a
+          href={`/api/checkout?pack=${pack}`}
+          className="flex items-center justify-center gap-2 w-full py-3 rounded-xl bg-primary text-primary-foreground text-sm font-bold hover:bg-primary/90 transition-colors"
+        >
+          <CreditCard className="h-4 w-4" />
+          {t("payWithStripe")} — USD ${selectedPack.price}
+        </a>
+
+        <a
+          href={`/api/checkout-mp?pack=${pack}`}
+          className="flex items-center justify-center gap-2 w-full py-3 rounded-xl border border-[#009ee3] text-[#009ee3] text-sm font-bold hover:bg-[#009ee3]/10 transition-colors"
+        >
+          {t("payWithMP")} — ${selectedPackCOP.price.toLocaleString("es-CO")} COP
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -4,6 +4,8 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
 import { CREDIT_PACKS } from "@/lib/stripe/config";
+import { CREDIT_PACKS_COP } from "@/lib/mercado-pago/config";
+import { createClient } from "@/lib/supabase/server";
 
 export async function generateMetadata({
   params,
@@ -18,8 +20,17 @@ export async function generateMetadata({
   };
 }
 
-export default function PricingPage() {
+export default async function PricingPage() {
   const t = useTranslations("pricing");
+
+  let isLoggedIn = false;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    isLoggedIn = !!user;
+  } catch {
+    // Not logged in
+  }
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-16 sm:py-24">
@@ -54,68 +65,96 @@ export default function PricingPage() {
       </h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {Object.values(CREDIT_PACKS).map((pack) => (
-          <div
-            key={pack.name}
-            className={`rounded-2xl bg-card p-8 flex flex-col relative ${
-              pack.popular
-                ? "border-2 border-primary shadow-lg"
-                : "border border-border"
-            }`}
-          >
-            {pack.popular && (
-              <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground text-xs font-medium px-3 py-1 rounded-full">
-                {t("bestValue")}
-              </div>
-            )}
-
-            <h3 className="text-xl font-bold mb-1">{pack.name}</h3>
-            <p className="text-muted-foreground text-sm mb-4">
-              {t("songsCount", { count: pack.credits })}
-            </p>
-
-            <div className="mb-6">
-              <span className="text-4xl font-bold">${pack.price}</span>
-              <span className="text-muted-foreground text-sm ml-1">
-                (${pack.pricePerSong.toFixed(2)}/song)
-              </span>
-            </div>
-
-            <ul className="space-y-2.5 mb-8 flex-1">
-              <li className="flex items-start gap-2 text-sm">
-                <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                {t("personalizedSongs", { count: pack.credits })}
-              </li>
-              <li className="flex items-start gap-2 text-sm">
-                <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                {t("babyNameInLyrics")}
-              </li>
-              <li className="flex items-start gap-2 text-sm">
-                <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                {t("mp3Download")}
-              </li>
-              <li className="flex items-start gap-2 text-sm">
-                <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                {t("shareableLink")}
-              </li>
-              <li className="flex items-start gap-2 text-sm">
-                <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                {t("creditsNeverExpire")}
-              </li>
-            </ul>
-
-            <Link
-              href="/auth/signup"
-              className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+        {Object.entries(CREDIT_PACKS).map(([packKey, pack]) => {
+          const packCOP = CREDIT_PACKS_COP[packKey as keyof typeof CREDIT_PACKS_COP];
+          return (
+            <div
+              key={pack.name}
+              className={`rounded-2xl bg-card p-8 flex flex-col relative ${
                 pack.popular
-                  ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                  : "border border-border hover:bg-muted"
+                  ? "border-2 border-primary shadow-lg"
+                  : "border border-border"
               }`}
             >
-              {t("buyCredits", { count: pack.credits })}
-            </Link>
-          </div>
-        ))}
+              {pack.popular && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground text-xs font-medium px-3 py-1 rounded-full">
+                  {t("bestValue")}
+                </div>
+              )}
+
+              <h3 className="text-xl font-bold mb-1">{pack.name}</h3>
+              <p className="text-muted-foreground text-sm mb-4">
+                {t("songsCount", { count: pack.credits })}
+              </p>
+
+              <ul className="space-y-2.5 mb-8 flex-1">
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("personalizedSongs", { count: pack.credits })}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("babyNameInLyrics")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("mp3Download")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("shareableLink")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("creditsNeverExpire")}
+                </li>
+              </ul>
+
+              {/* Payment buttons */}
+              <div className="flex flex-col gap-2">
+                {isLoggedIn ? (
+                  <a
+                    href={`/api/checkout?pack=${packKey}`}
+                    className={`block py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+                      pack.popular
+                        ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                        : "border border-border hover:bg-muted"
+                    }`}
+                  >
+                    {t("payWithStripe")} — USD ${pack.price}
+                  </a>
+                ) : (
+                  <Link
+                    href="/auth/signup"
+                    className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+                      pack.popular
+                        ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                        : "border border-border hover:bg-muted"
+                    }`}
+                  >
+                    {t("payWithStripe")} — USD ${pack.price}
+                  </Link>
+                )}
+
+                {isLoggedIn ? (
+                  <a
+                    href={`/api/checkout-mp?pack=${packKey}`}
+                    className="block py-2.5 rounded-xl text-sm font-bold text-center border border-[#009ee3] text-[#009ee3] hover:bg-[#009ee3]/10 transition-colors"
+                  >
+                    {t("payWithMP")} — ${packCOP.price.toLocaleString("es-CO")} COP
+                  </a>
+                ) : (
+                  <Link
+                    href="/auth/signup"
+                    className="py-2.5 rounded-xl text-sm font-bold text-center border border-[#009ee3] text-[#009ee3] hover:bg-[#009ee3]/10 transition-colors"
+                  >
+                    {t("payWithMP")} — ${packCOP.price.toLocaleString("es-CO")} COP
+                  </Link>
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
-import { Check, Sparkles, Gift } from "lucide-react";
-import { CREDIT_PACKS } from "@/lib/stripe/credit-packs";
-import { CREDIT_PACKS_COP } from "@/lib/mercado-pago/config";
-import { createClient } from "@/lib/supabase/server";
+import { Sparkles, Gift } from "lucide-react";
+import { PricingPacks } from "@/components/pricing/PricingPacks";
 
 export async function generateMetadata({
   params,
@@ -26,34 +24,20 @@ export default async function PricingPage({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "pricing" });
-
-  let isLoggedIn = false;
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    isLoggedIn = !!user;
-  } catch {
-    // Not logged in
-  }
+  // Note: PricingPacks (Client Component) uses useTranslations("pricing") internally
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-16 sm:py-24">
       <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold mb-4">
-          {t("heroTitle")}
-        </h1>
-        <p className="text-lg text-muted-foreground">
-          {t("heroSubtitle")}
-        </p>
+        <h1 className="text-4xl font-bold mb-4">{t("heroTitle")}</h1>
+        <p className="text-lg text-muted-foreground">{t("heroSubtitle")}</p>
       </div>
 
       {/* Free tier */}
       <div className="max-w-md mx-auto mb-12 p-6 rounded-2xl border-2 border-primary/30 bg-gradient-to-br from-primary/5 to-gold/10 text-center">
         <Gift className="h-8 w-8 text-primary mx-auto mb-3" />
         <h3 className="text-lg font-bold mb-1">{t("firstSongFree")}</h3>
-        <p className="text-sm text-muted-foreground mb-4">
-          {t("firstSongFreeDesc")}
-        </p>
+        <p className="text-sm text-muted-foreground mb-4">{t("firstSongFreeDesc")}</p>
         <Link
           href="/create"
           className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-6 py-2.5 rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors"
@@ -63,103 +47,10 @@ export default async function PricingPage({
         </Link>
       </div>
 
-      {/* Credit packs */}
-      <h2 className="text-2xl font-bold text-center mb-8">
-        {t("needMoreSongs")}
-      </h2>
+      <h2 className="text-2xl font-bold text-center mb-2">{t("needMoreSongs")}</h2>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {Object.entries(CREDIT_PACKS).map(([packKey, pack]) => {
-          const packCOP = CREDIT_PACKS_COP[packKey as keyof typeof CREDIT_PACKS_COP];
-          return (
-            <div
-              key={pack.name}
-              className={`rounded-2xl bg-card p-8 flex flex-col relative ${
-                pack.popular
-                  ? "border-2 border-primary shadow-lg"
-                  : "border border-border"
-              }`}
-            >
-              {pack.popular && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground text-xs font-medium px-3 py-1 rounded-full">
-                  {t("bestValue")}
-                </div>
-              )}
-
-              <h3 className="text-xl font-bold mb-1">{pack.name}</h3>
-              <p className="text-muted-foreground text-sm mb-4">
-                {t("songsCount", { count: pack.credits })}
-              </p>
-
-              <ul className="space-y-2.5 mb-8 flex-1">
-                <li className="flex items-start gap-2 text-sm">
-                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                  {t("personalizedSongs", { count: pack.credits })}
-                </li>
-                <li className="flex items-start gap-2 text-sm">
-                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                  {t("babyNameInLyrics")}
-                </li>
-                <li className="flex items-start gap-2 text-sm">
-                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                  {t("mp3Download")}
-                </li>
-                <li className="flex items-start gap-2 text-sm">
-                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                  {t("shareableLink")}
-                </li>
-                <li className="flex items-start gap-2 text-sm">
-                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                  {t("creditsNeverExpire")}
-                </li>
-              </ul>
-
-              {/* Payment buttons */}
-              <div className="flex flex-col gap-2">
-                {isLoggedIn ? (
-                  <a
-                    href={`/api/checkout?pack=${packKey}`}
-                    className={`block py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
-                      pack.popular
-                        ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                        : "border border-border hover:bg-muted"
-                    }`}
-                  >
-                    {t("payWithStripe")} — USD ${pack.price}
-                  </a>
-                ) : (
-                  <Link
-                    href="/auth/signup"
-                    className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
-                      pack.popular
-                        ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                        : "border border-border hover:bg-muted"
-                    }`}
-                  >
-                    {t("payWithStripe")} — USD ${pack.price}
-                  </Link>
-                )}
-
-                {isLoggedIn ? (
-                  <a
-                    href={`/api/checkout-mp?pack=${packKey}`}
-                    className="block py-2.5 rounded-xl text-sm font-bold text-center border border-[#009ee3] text-[#009ee3] hover:bg-[#009ee3]/10 transition-colors"
-                  >
-                    {t("payWithMP")} — ${packCOP.price.toLocaleString("es-CO")} COP
-                  </a>
-                ) : (
-                  <Link
-                    href="/auth/signup"
-                    className="py-2.5 rounded-xl text-sm font-bold text-center border border-[#009ee3] text-[#009ee3] hover:bg-[#009ee3]/10 transition-colors"
-                  >
-                    {t("payWithMP")} — ${packCOP.price.toLocaleString("es-CO")} COP
-                  </Link>
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      {/* Client component handles currency toggle + pack grid */}
+      <PricingPacks locale={locale} />
     </div>
   );
 }

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
@@ -20,8 +19,13 @@ export async function generateMetadata({
   };
 }
 
-export default async function PricingPage() {
-  const t = useTranslations("pricing");
+export default async function PricingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "pricing" });
 
   let isLoggedIn = false;
   try {

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { Check, Sparkles, Gift } from "lucide-react";
-import { CREDIT_PACKS } from "@/lib/stripe/config";
+import { CREDIT_PACKS } from "@/lib/stripe/credit-packs";
 import { CREDIT_PACKS_COP } from "@/lib/mercado-pago/config";
 import { createClient } from "@/lib/supabase/server";
 

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -8,8 +8,9 @@ async function createCheckoutSession(
   request: Request,
   userId: string,
   email: string | undefined,
-  priceId: string,
+  pack: PackKey,
 ) {
+  const selectedPack = CREDIT_PACKS[pack];
   const supabase = await createClient();
 
   const { data: profile } = await supabase
@@ -35,17 +36,27 @@ async function createCheckoutSession(
 
   const session = await getStripe().checkout.sessions.create({
     customer: customerId,
-    line_items: [{ price: priceId, quantity: 1 }],
+    line_items: [{
+      price_data: {
+        currency: "usd",
+        unit_amount: Math.round(selectedPack.price * 100),
+        product_data: {
+          name: `BabyBeats ${selectedPack.name}`,
+          description: `${selectedPack.credits} personalized songs`,
+        },
+      },
+      quantity: 1,
+    }],
     mode: "payment",
     success_url: `${process.env.NEXT_PUBLIC_APP_URL}/profile?success=true`,
     cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/pricing?canceled=true`,
-    metadata: { supabase_user_id: userId, price_id: priceId },
+    metadata: { supabase_user_id: userId, pack },
   });
 
   return NextResponse.redirect(session.url!);
 }
 
-// Called from pricing page as GET /api/checkout?pack=starter
+// Called from checkout page as GET /api/checkout?pack=starter
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const pack = searchParams.get("pack") as PackKey | null;
@@ -61,12 +72,16 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL("/auth/login", request.url));
   }
 
-  return createCheckoutSession(request, user.id, user.email, CREDIT_PACKS[pack].priceId);
+  return createCheckoutSession(request, user.id, user.email, pack);
 }
 
-// POST kept for backwards compatibility (called via fetch from other clients)
+// POST kept for backwards compatibility
 export async function POST(request: Request) {
-  const { priceId } = await request.json();
+  const { pack } = await request.json() as { pack: PackKey };
+
+  if (!pack || !(pack in CREDIT_PACKS)) {
+    return NextResponse.json({ error: "Invalid pack" }, { status: 400 });
+  }
 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -75,5 +90,5 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  return createCheckoutSession(request, user.id, user.email, priceId);
+  return createCheckoutSession(request, user.id, user.email, pack);
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -39,10 +39,8 @@ export async function POST(request: Request) {
 
       // Handle one-time credit pack purchase
       if (session.mode === "payment") {
-        const priceId = session.metadata?.price_id;
-        const pack = Object.values(CREDIT_PACKS).find(
-          (p) => p.priceId === priceId,
-        );
+        const packKey = session.metadata?.pack as keyof typeof CREDIT_PACKS | undefined;
+        const pack = packKey ? CREDIT_PACKS[packKey] : undefined;
 
         if (pack) {
           // Atomic credit addition

--- a/src/components/pricing/PricingPacks.tsx
+++ b/src/components/pricing/PricingPacks.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Check } from "lucide-react";
+import { CREDIT_PACKS } from "@/lib/stripe/credit-packs";
+import { CREDIT_PACKS_COP } from "@/lib/mercado-pago/config";
+
+type Currency = "USD" | "COP";
+
+export function PricingPacks({ locale }: { locale: string }) {
+  const t = useTranslations("pricing");
+  const [currency, setCurrency] = useState<Currency>("USD");
+
+  return (
+    <>
+      {/* Currency selector */}
+      <div className="flex justify-center mb-8 mt-6">
+        <div className="inline-flex rounded-xl border border-border p-1 gap-1">
+          {(["USD", "COP"] as Currency[]).map((c) => (
+            <button
+              key={c}
+              onClick={() => setCurrency(c)}
+              className={`px-5 py-1.5 rounded-lg text-sm font-semibold transition-colors ${
+                currency === c
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {c === "USD" ? t("currencyUSD") : t("currencyCOP")}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Packs grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {Object.entries(CREDIT_PACKS).map(([packKey, pack]) => {
+          const packCOP = CREDIT_PACKS_COP[packKey as keyof typeof CREDIT_PACKS_COP];
+          const displayPrice = currency === "USD"
+            ? `USD $${pack.price}`
+            : `$${packCOP.price.toLocaleString("es-CO")} COP`;
+
+          return (
+            <div
+              key={packKey}
+              className={`rounded-2xl bg-card p-8 flex flex-col relative ${
+                pack.popular
+                  ? "border-2 border-primary shadow-lg"
+                  : "border border-border"
+              }`}
+            >
+              {pack.popular && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground text-xs font-medium px-3 py-1 rounded-full">
+                  {t("bestValue")}
+                </div>
+              )}
+
+              <h3 className="text-xl font-bold mb-1">{pack.name}</h3>
+              <p className="text-muted-foreground text-sm mb-4">
+                {t("songsCount", { count: pack.credits })}
+              </p>
+
+              <div className="mb-6">
+                <span className="text-3xl font-bold">{displayPrice}</span>
+              </div>
+
+              <ul className="space-y-2.5 mb-8 flex-1">
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("personalizedSongs", { count: pack.credits })}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("babyNameInLyrics")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("mp3Download")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("shareableLink")}
+                </li>
+                <li className="flex items-start gap-2 text-sm">
+                  <Check className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  {t("creditsNeverExpire")}
+                </li>
+              </ul>
+
+              <a
+                href={`/${locale}/checkout/${packKey}`}
+                className={`py-2.5 rounded-xl text-sm font-bold text-center transition-colors ${
+                  pack.popular
+                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "border border-border hover:bg-muted"
+                }`}
+              >
+                {t("choosePlan")}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/lib/stripe/credit-packs.ts
+++ b/src/lib/stripe/credit-packs.ts
@@ -7,7 +7,6 @@ export const CREDIT_PACKS = {
     credits: 3,
     price: 4.99,
     pricePerSong: 1.66,
-    priceId: process.env.STRIPE_STARTER_PACK_PRICE_ID || "",
     popular: false,
   },
   popular: {
@@ -15,7 +14,6 @@ export const CREDIT_PACKS = {
     credits: 10,
     price: 9.99,
     pricePerSong: 1.0,
-    priceId: process.env.STRIPE_FAMILY_PACK_PRICE_ID || "",
     popular: true,
   },
   mega: {
@@ -23,7 +21,8 @@ export const CREDIT_PACKS = {
     credits: 25,
     price: 19.99,
     pricePerSong: 0.8,
-    priceId: process.env.STRIPE_MEGA_PACK_PRICE_ID || "",
     popular: false,
   },
 } as const;
+
+export type CreditPackKey = keyof typeof CREDIT_PACKS;


### PR DESCRIPTION
## Summary
- **Pricing page**: un solo botón "Elegir" por plan + toggle USD/COP que cambia los precios mostrados en tiempo real
- **Nueva página `/checkout/[pack]`**: resumen del pedido con precio en ambas monedas + dos botones de pago (Stripe y Mercado Pago). Redirige a login si el usuario no está autenticado.
- **Stripe dynamic pricing**: eliminados los `priceId` de env vars — el precio se pasa inline a Stripe en el momento del checkout. Solo se necesitan `STRIPE_SECRET_KEY` y `STRIPE_WEBHOOK_SECRET`.

## Variables de entorno que ya NO son necesarias en Vercel
```
STRIPE_STARTER_PACK_PRICE_ID  ← eliminar
STRIPE_FAMILY_PACK_PRICE_ID   ← eliminar
STRIPE_MEGA_PACK_PRICE_ID     ← eliminar
```

## Test plan
- [ ] `/es/pricing` carga con toggle USD/COP funcional
- [ ] Cambiar a COP muestra "$15.000 COP", "$29.000 COP", "$59.000 COP"
- [ ] Clic en "Elegir" → va a `/es/checkout/popular`
- [ ] Sin sesión → redirige a login y vuelve al checkout
- [ ] Con sesión → muestra resumen + botones de pago
- [ ] Pack inválido (`/checkout/abc`) → redirige a pricing
- [ ] `npm run build` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)